### PR TITLE
Add a sunset warning

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -12,6 +12,7 @@ html(lang="en")
 
       #warning
         span This documentation is no longer supported, please refer to the <a href="https://devcenter.heroku.com/platform-api-reference">platform API reference</a>.
+        h2 This API <a href="https://devcenter.heroku.com/changelog-items/862">will be sunset on April 15, 2017</a>.
 
       #header
         #api_key


### PR DESCRIPTION
I added a PR to API to add a warning before the Legacy API link, but seems like we should have one here as well.

![screen shot 2016-09-28 at 5 19 30 pm](https://cloud.githubusercontent.com/assets/16557/18936844/c237d3e8-859f-11e6-906c-f00475e42e78.png)

Text look OK?

/cc @geemus 